### PR TITLE
标准化缩进

### DIFF
--- a/src/utils/DefaultConfig.js
+++ b/src/utils/DefaultConfig.js
@@ -36,7 +36,21 @@ export const defaultConfig = {
     editorOption: {
         mode: 'gfm',
         lineNumbers: true,
-        lineWrapping: true
+        lineWrapping: true,
+        indentUnit: 4,
+        tabSize: 4,
+
+        extraKeys: {
+            // To standardize the indentation
+            Tab: (cm) => {
+                if (cm.somethingSelected()) {
+                    cm.execCommand("indentMore");
+                }
+                else {
+                    cm.execCommand("insertSoftTab");
+                }
+            }
+        }
     },
     scrollSync: true
 }


### PR DESCRIPTION
- 现在当按下 <kbd>Tab </kbd> 时将会键入 4 个空格而不是 \t
- 选中文本并缩进时将会缩进 4 个空格而不是 2 个
